### PR TITLE
fix: make sidebar easier to trigger and add a new method to check live on YT

### DIFF
--- a/src/components/VideoPlayerV2/index.tsx
+++ b/src/components/VideoPlayerV2/index.tsx
@@ -207,6 +207,8 @@ const VideoPlayerV2Inner = observer(
       }
     })
 
+    const [isSideHovered, setSideIsHovered] = useState(false);
+
     return (
       <div
         className={classNames(
@@ -320,9 +322,11 @@ const VideoPlayerV2Inner = observer(
 
         {/* 侧边操作栏 */}
         {props.sideSwitcher && (
-          <div className="side-action-area ab-vertical-center transition-all duration-500 h-full z-[11] right-[calc(var(--side-width)*-1)] w-[calc(var(--side-width)+10px)] hover:right-0 group/side">
+          <div className="side-action-area ab-vertical-center transition-all duration-500 h-full z-[11] right-[calc(var(--side-width)*-1)] w-[calc(var(--side-width)+15px)] hover:right-0 group/side"
+            onMouseEnter={() => setSideIsHovered(true)}
+            onMouseLeave={() => setSideIsHovered(false)}>
             <VideoPlayerSide sideSwitcher={props.sideSwitcher} />
-            <div className="side-dragger !group-hover/side:opacity-0 group-[&.action-area-active]:opacity-100 opacity-0 absolute ab-vertical-center w-[10px] h-[30px] bg-[#0007] rounded-tl-[5px] rounded-bl-[5px] transition-all"></div>
+            <div className="side-dragger !group-hover/side:opacity-0 group-[&.action-area-active]:opacity-100 opacity-0 absolute ab-vertical-center w-[15px] h-[30px] bg-[#0007] rounded-tl-[5px] rounded-bl-[5px] transition-all leading-[30px] text-white text-center"> {isSideHovered ? '>' : '<'} </div>
           </div>
         )}
       </div>

--- a/src/store/config/index.ts
+++ b/src/store/config/index.ts
@@ -110,6 +110,12 @@ export const baseConfigMap = {
     relateByValue: true,
   }),
   // debug
+  useIframeToDetectIsLiveOnYoutube: config({
+    defaultValue: true,
+    label: 'useIframeDetectionOnYT',
+    desc: 'use chat iframe to decect isLive on Youtube, else use HTML element',
+    notRecommended: true,
+  }),
   performanceInfo: config({
     defaultValue: false,
     label: t('settingPanel.performanceInfo'),

--- a/src/web-provider/youtube/index.ts
+++ b/src/web-provider/youtube/index.ts
@@ -5,10 +5,11 @@ import onRouteChange from '@root/inject/csUtils/onRouteChange'
 import { SideSwitcher } from '@root/core/SideSwitcher'
 import { t } from '@root/utils/i18n'
 import { VideoItem } from '@root/components/VideoPlayer/Side'
+import configStore from '@root/store/config'
 
 const getIframe = () => dq1<HTMLIFrameElement>('.ytd-live-chat-frame')
-const isLive = () => !!getIframe()
-
+const getLiveClass = () => dq1<HTMLDivElement>('.ytp-live')
+const isLive = () => configStore.useIframeToDetectIsLiveOnYoutube ? !!getIframe() : !!getLiveClass()
 export default class YoutubeProvider extends HtmlDanmakuProvider {
   onInit() {
     this.isLive = isLive()


### PR DESCRIPTION
I'm not sure if it was intentionally designed this way, but the sidebar requires a click to be triggered, which is not very convenient. Therefore, I increased the trigger area's width by _5px_ and added a symbol to make it more noticeable.

Before:

https://github.com/user-attachments/assets/aeb996f1-3a4a-4ec0-a109-c923d6635fad

After:

https://github.com/user-attachments/assets/ebf9cbf8-9760-4d9c-adb0-a95f1d6bc509

