### PR TITLE
feat: 触发新PIP时在标题后添加 ' - PIP'

### DIFF
--- a/src/core/WebProvider/DocPIPWebProvider.ts
+++ b/src/core/WebProvider/DocPIPWebProvider.ts
@@ -21,6 +21,11 @@ export default class DocPIPWebProvider extends WebProvider {
   pipWindow?: Window
 
   async onOpenPlayer() {
+    // 在标题后添加 ' - PIP'
+    const title = document.title
+    const pipTitle = title + ' - PIP'
+    document.title = pipTitle
+
     // 获取应该有的docPIP宽高
     const pipWindowConfig = await getBrowserSyncStorage(PIP_WINDOW_CONFIG)
     let width = pipWindowConfig?.width ?? this.webVideo.clientWidth,
@@ -211,6 +216,9 @@ export default class DocPIPWebProvider extends WebProvider {
       this.emit(PlayerEvent.close)
       pipWindow.removeEventListener('wheel', handleWheel)
       sendMessage(WebextEvent.closePIP, null)
+
+      // 恢复原始标题
+      document.title = title
     })
     pipWindow.addEventListener('resize', () => {
       this.emit(PlayerEvent.resize)


### PR DESCRIPTION
由于新PIP窗口的系统标题是基于原始网站的标题. 使得WM (`yabai`i, `komorebi`)难以通过标题规则来判断是否浮动窗口。
本修改在触发新PIP后，在标题后面添加 ‘- PIP’以方便WM判断，在结束PIP后恢复原始标题
![image](https://github.com/user-attachments/assets/7ad35441-6088-47c1-9b95-b618d8615873)
