### PR TITLE
fix: cleanup keydown listeners and autoPIP trigger logic

### DIFF
--- a/src/components/VideoPlayerV2/hooks.ts
+++ b/src/components/VideoPlayerV2/hooks.ts
@@ -164,8 +164,10 @@ export function useKeydown(
 
     return () => {
       keydownWindow.removeEventListener('keydown', handleKeyDown)
-
-      keydownWindow.addEventListener('dm-keydown' as any, handleKeyDownCustom)
+      keydownWindow.removeEventListener(
+        'dm-keydown' as any,
+        handleKeyDownCustom,
+      )
     }
   }, [keydownWindow, isLive])
 }

--- a/src/hook/useAutoPIPHandler.ts
+++ b/src/hook/useAutoPIPHandler.ts
@@ -107,7 +107,7 @@ const startPIP = async (
               observer.disconnect()
 
               // 由于b站有下滚自动小窗，跟此功能冲突，用scroll来触发
-              if (now - new Date().getTime() < 1000) {
+              if (new Date().getTime() - now < 1000) {
                 if (type === 'scrollOut') {
                   const unListenScroll = addEventListener(window, (window) => {
                     window.addEventListener('scroll', () => {
@@ -162,12 +162,16 @@ export default function useAutoPIPHandler(videoEl: HTMLVideoElement) {
     'play',
     () => {
       if (!canRun) return
-      videoEl.addEventListener('play', () => {
-        observeVideo(videoEl)
-      })
-      videoEl.addEventListener('volumechange', () => {
-        observeVideo(videoEl)
-      })
+      observeVideo(videoEl)
+    },
+    videoEl,
+  )
+
+  useTargetEventListener(
+    'volumechange',
+    () => {
+      if (!canRun) return
+      observeVideo(videoEl)
     },
     videoEl,
   )


### PR DESCRIPTION
## Summary
- fix listener cleanup typo in VideoPlayerV2 useKeydown (remove dm-keydown handler on unmount)
- fix time comparison direction in autoPIP close-on-return flow
- avoid repeated play/volumechange listener registration in autoPIP hook

## Fixes
- prevents duplicated keyboard handling after re-mount/switch
- makes auto close behavior consistent when returning to origin position
- reduces potential event listener leaks in autoPIP
