### PR TITLE
fix: prevent shortcut fields from reusing number inputs

### DIFF
--- a/src/store/config/shortcut.tsx
+++ b/src/store/config/shortcut.tsx
@@ -24,6 +24,9 @@ const config: typeof _config = (props) => ({
     return (
       <>
         <input
+          type="text"
+          autoComplete="off"
+          spellCheck={false}
           value={value}
           onKeyDown={(e) => {
             e.preventDefault()
@@ -74,6 +77,9 @@ const config: typeof _config = (props) => ({
 
 export const disableRender = (val: Key[]) => (
   <input
+    type="text"
+    autoComplete="off"
+    spellCheck={false}
     value={val.join(' + ')}
     disabled
     style={{ cursor: 'not-allowed' }}


### PR DESCRIPTION
When switching settings tabs, React reuses row DOM by index. A numeric field (`type=number`) can then receive a shortcut string such as `Shift + →`, and Chrome logs:

```
The specified value "Shift + →" cannot be parsed, or is out of range.
```

Set `type="text"` on shortcut inputs so the input type is updated instead of staying `number`.

Only change: `src/store/config/shortcut.tsx`.
